### PR TITLE
Stronger validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 21.5b2
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade

--- a/cryopose/_constructor.py
+++ b/cryopose/_constructor.py
@@ -1,14 +1,16 @@
-from typing import Mapping, Optional, Sequence, TypeVar, Union, Literal
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Mapping, Sequence
 
 import numpy as np
 import pandas as pd
 from scipy.spatial.transform import Rotation
 
 from ._data_labels import CryoPoseDataLabels as CPDL
-from ._validators import validate_positions, validate_orientations, validate_cryopose
+from ._validators import validate_cryopose, validate_orientations, validate_positions
 
-
-_T = TypeVar("_T")
+if TYPE_CHECKING:
+    import Literal
 
 
 def _construct_empty_cryopose_df(ndim: Literal[2, 3] = 3) -> pd.DataFrame:
@@ -24,10 +26,10 @@ def _construct_empty_cryopose_df(ndim: Literal[2, 3] = 3) -> pd.DataFrame:
 
 def construct_cryopose_df(
     positions: np.ndarray,
-    orientations: Optional[Rotation] = None,
-    experiment_ids: Optional[Union[str, Sequence[str]]] = None,
-    pixel_spacing_angstroms: Optional[Union[float, Sequence[float]]] = None,
-    metadata: Optional[Mapping[str, Sequence]] = None,
+    orientations: Rotation | None = None,
+    experiment_ids: str | Sequence[str] | None = None,
+    pixel_spacing_angstroms: float | Sequence[float] | None = None,
+    metadata: Mapping[str, Sequence] | None = None,
     ndim: Literal[2, 3] = 3,
 ) -> pd.DataFrame:
     """Constructor for a valid cryopose DataFrame."""
@@ -43,7 +45,7 @@ def construct_cryopose_df(
     df[CPDL.PIXEL_SPACING] = pixel_spacing_angstroms
 
     if experiment_ids is None:
-        experiment_ids = '0'
+        experiment_ids = "0"
     df[CPDL.EXPERIMENT_ID] = experiment_ids
 
     # optional columns

--- a/cryopose/_data_labels.py
+++ b/cryopose/_data_labels.py
@@ -2,6 +2,7 @@ class CryoPoseDataLabels:
     POSITION_X = "x"
     POSITION_Y = "y"
     POSITION_Z = "z"
+    POSITION = [POSITION_X, POSITION_Y, POSITION_Z]
 
     ORIENTATION = "orientation"
 

--- a/cryopose/_utils.py
+++ b/cryopose/_utils.py
@@ -1,10 +1,6 @@
-from typing import List, Optional, Sequence, Union
+from typing import List, Sequence, Union
 
-import numpy as np
-import pandas as pd
 from scipy.spatial.transform import Rotation
-
-from ._data_labels import CryoPoseDataLabels as CPDL
 
 
 def unstack_rotations(rotations: Union[Rotation, Sequence[Rotation]]) -> List[Rotation]:
@@ -15,25 +11,3 @@ def unstack_rotations(rotations: Union[Rotation, Sequence[Rotation]]) -> List[Ro
 def stack_rotations(rotations: Sequence[Rotation]) -> Rotation:
     """Stack a sequence of Rotations into one Rotation object."""
     return Rotation.concatenate(rotations)
-
-
-def guess_ndim(positions: np.ndarray) -> int:
-    """Guess dimensionality or 2D or 3D coordinate data."""
-    try:
-        positions.reshape((-1, 2))
-        ndim = 2
-    except ValueError:
-        positions.reshape((-1, 3))
-        ndim = 3
-    return ndim
-
-
-def add_particle_orientations(
-    df: pd.DataFrame, orientations: Optional[Rotation]
-) -> pd.DataFrame:
-    """Add particle orientations to a cryopose dataframe."""
-    if orientations is None:
-        n_particles = df.shape[0]
-        orientations = Rotation.identity(num=n_particles)
-    df[CPDL.ORIENTATION] = unstack_rotations(orientations)
-    return df

--- a/cryopose/_validators.py
+++ b/cryopose/_validators.py
@@ -1,24 +1,35 @@
-from typing import Union, Sequence, Literal
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
 import pandas as pd
+from numpy.typing import ArrayLike, NDArray
 from pandas.api.types import is_numeric_dtype, is_string_dtype
 from scipy.spatial.transform import Rotation
 
 from ._data_labels import CryoPoseDataLabels as CPDL
 
+if TYPE_CHECKING:
+    import Literal
+
 
 def validate_positions(positions: ArrayLike, ndim: Literal[2, 3] = 3) -> NDArray:
     positions = np.asarray(positions, dtype=float)
     if positions.ndim != 2 or positions.shape[1] not in (2, 3):
-        raise ValueError(f'positions must be a (n, 2) or (n, 3) array, got {positions.shape}')
+        raise ValueError(
+            f"positions must be a (n, 2) or (n, 3) array, got {positions.shape}"
+        )
     if ndim != positions.shape[1]:
-        raise ValueError(f'positions are {positions.shape[1]}D, but a {ndim}D cryopose was requested')
+        raise ValueError(
+            f"positions are {positions.shape[1]}D, but a {ndim}D cryopose was requested"
+        )
     return positions
 
 
-def validate_orientations(orientations: Union[Rotation, Sequence[Rotation]], ndim: Literal[2, 3] = 3) -> Rotation:
+def validate_orientations(
+    orientations: Rotation | Sequence[Rotation], ndim: Literal[2, 3] = 3
+) -> Rotation:
     return Rotation.concatenate(orientations)
 
 
@@ -32,18 +43,24 @@ def validate_cryopose(df: pd.DataFrame, ndim: Literal[2, 3] = 3) -> pd.DataFrame
 
     if CPDL.ORIENTATION not in df:
         raise KeyError(CPDL.ORIENTATION)
-    # cannot just check dtype, which will just be object, so we have to validate the objects themselves
+    # cannot just check dtype, so we have to validate the objects themselves
     if len(df) > 0:
         validate_orientations(df[CPDL.ORIENTATION], ndim=ndim)
 
     if CPDL.PIXEL_SPACING not in df:
         raise KeyError(CPDL.PIXEL_SPACING)
     if not is_numeric_dtype(df[CPDL.PIXEL_SPACING]):
-        raise TypeError(f'dtype of "{CPDL.PIXEL_SPACING}" should be a Number, got {df[CPDL.PIXEL_SPACING].dtype}')
+        raise TypeError(
+            f'dtype of "{CPDL.PIXEL_SPACING}" should be a Number, '
+            f"got {df[CPDL.PIXEL_SPACING].dtype}"
+        )
 
     if CPDL.EXPERIMENT_ID not in df:
         raise KeyError(CPDL.EXPERIMENT_ID)
     if not is_string_dtype(df[CPDL.EXPERIMENT_ID]):
-        raise TypeError(f'dtype of "{CPDL.EXPERIMENT_ID}" should be a string, got {df[CPDL.EXPERIMENT_ID].dtype}')
+        raise TypeError(
+            f'dtype of "{CPDL.EXPERIMENT_ID}" should be a string, '
+            f"got {df[CPDL.EXPERIMENT_ID].dtype}"
+        )
 
     return df

--- a/cryopose/_validators.py
+++ b/cryopose/_validators.py
@@ -19,11 +19,7 @@ def validate_positions(positions: ArrayLike, ndim: Literal[2, 3] = 3) -> NDArray
 
 
 def validate_orientations(orientations: Union[Rotation, Sequence[Rotation]], ndim: Literal[2, 3] = 3) -> Rotation:
-    orientations = Rotation.concatenate(orientations)
-    if ndim == 2:
-        # TODO: check that rotation is only inplane?
-        ...
-    return orientations
+    return Rotation.concatenate(orientations)
 
 
 def validate_cryopose(df: pd.DataFrame, ndim: Literal[2, 3] = 3) -> pd.DataFrame:

--- a/cryopose/_validators.py
+++ b/cryopose/_validators.py
@@ -1,24 +1,53 @@
+from typing import Union, Sequence, Literal
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
 import pandas as pd
+from pandas.api.types import is_numeric_dtype, is_string_dtype
+from scipy.spatial.transform import Rotation
 
 from ._data_labels import CryoPoseDataLabels as CPDL
 
 
-def validate_3d_cryopose_df(df: pd.DataFrame) -> bool:
-    """Validate a cryopose dataframe for particle poses in 3D."""
-    required_columns_3d = [
-        CPDL.POSITION_X,
-        CPDL.POSITION_Y,
-        CPDL.POSITION_Z,
-        CPDL.ORIENTATION,
-    ]
-    return all(k in df for k in required_columns_3d)
+def validate_positions(positions: ArrayLike, ndim: Literal[2, 3] = 3) -> NDArray:
+    positions = np.asarray(positions, dtype=float)
+    if positions.ndim != 2 or positions.shape[1] not in (2, 3):
+        raise ValueError(f'positions must be a (n, 2) or (n, 3) array, got {positions.shape}')
+    if ndim != positions.shape[1]:
+        raise ValueError(f'positions are {positions.shape[1]}D, but a {ndim}D cryopose was requested')
+    return positions
 
 
-def validate_2d_cryopose_df(df: pd.DataFrame) -> bool:
-    """Validate a cryopose dataframe for particle poses in 3D."""
-    required_columns_2d = [
-        CPDL.POSITION_X,
-        CPDL.POSITION_Y,
-        CPDL.ORIENTATION,
-    ]
-    return all(k in df for k in required_columns_2d)
+def validate_orientations(orientations: Union[Rotation, Sequence[Rotation]], ndim: Literal[2, 3] = 3) -> Rotation:
+    orientations = Rotation.concatenate(orientations)
+    if ndim == 2:
+        # TODO: check that rotation is only inplane?
+        ...
+    return orientations
+
+
+def validate_cryopose(df: pd.DataFrame, ndim: Literal[2, 3] = 3) -> pd.DataFrame:
+    """Validate a cryopose dataframe."""
+    for col in CPDL.POSITION[:ndim]:
+        if col not in df:
+            raise KeyError(col)
+        if not is_numeric_dtype(df[col]):
+            raise TypeError(f'dtype of "{col}" should be a Number, got {df[col].dtype}')
+
+    if CPDL.ORIENTATION not in df:
+        raise KeyError(CPDL.ORIENTATION)
+    # cannot just check dtype, which will just be object, so we have to validate the objects themselves
+    if len(df) > 0:
+        validate_orientations(df[CPDL.ORIENTATION], ndim=ndim)
+
+    if CPDL.PIXEL_SPACING not in df:
+        raise KeyError(CPDL.PIXEL_SPACING)
+    if not is_numeric_dtype(df[CPDL.PIXEL_SPACING]):
+        raise TypeError(f'dtype of "{CPDL.PIXEL_SPACING}" should be a Number, got {df[CPDL.PIXEL_SPACING].dtype}')
+
+    if CPDL.EXPERIMENT_ID not in df:
+        raise KeyError(CPDL.EXPERIMENT_ID)
+    if not is_string_dtype(df[CPDL.EXPERIMENT_ID]):
+        raise TypeError(f'dtype of "{CPDL.EXPERIMENT_ID}" should be a string, got {df[CPDL.EXPERIMENT_ID].dtype}')
+
+    return df

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     numpy
     pandas
     scipy
-python_requires = >=3.8
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 zip_safe = False


### PR DESCRIPTION
First of all, sorry for the big blob of changes, at this stage it's aways easier to refactor a lot of things than splitting in small atomic changes... In summary:

validation was not quite there yet; especially ndim guessing was failing regularly (`reshape(-1, 2)` was working for any array with even number of elements :P). I added a bunch of checks for data types and values that hopefully should ensure the object is indeed complying.

In here, we currently intermix 2 types of validation without distinction, which is probably bad: *checking* if thigns are correct (`validate_cryopose`) and *enforcing* correct things as much as possible (`validate_positions`). We should probably formalize this, because I can see cases where someone wants the positions in 3D no matter what (just pad it if 2D)
