### PR TITLE
Use pyproject.toml and add test/deploy workflow

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -1,0 +1,72 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: ${{ matrix.platform }} (${{ matrix.python-version }})
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools tox tox-gh-actions
+      - name: Test with tox
+        run: python -m tox
+        env:
+          PLATFORM: ${{ matrix.platform }}
+      - name: Coverage
+        if: runner.os == 'Linux'
+        uses: codecov/codecov-action@v2
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'teamtomo/cryopose' && contains(github.ref, 'tags') }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U setuptools setuptools_scm wheel twine build
+      - name: Build
+        run: |
+          git tag
+          python -m build
+          twine check dist/*
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+          body_path: ${{ github.workspace }}/CHANGELOG.md
+      - name: Publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
+        run: twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "setuptools_scm[toml]>=3.4"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "cryopose/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ project_urls =
 packages = find:
 install_requires =
     numpy
-    scipy
     pandas
+    scipy
     typing_extensions
 python_requires = >=3.7
 setup_requires =
@@ -45,8 +45,12 @@ dev =
     pre-commit
     pydocstyle
     pytest
+    pytest-cov
+    tox
 testing =
     pytest
+    pytest-cov
+    tox
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-import setuptools
-
-setuptools.setup(use_scm_version={"write_to": "cryopose/_version.py"})

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,64 @@
+[tox]
+envlist = py{38,39,310}-{linux,macos,windows}
+toxworkdir=/tmp/.tox
+isolated_build = True
+
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
+[gh-actions:env]
+PLATFORM =
+    ubuntu-latest: linux
+    macos-latest: macos
+    windows-latest: windows
+
+[testenv]
+platform =
+    macos: darwin
+    linux: linux
+    windows: win32
+passenv =
+    CI
+    GITHUB_ACTIONS
+    DISPLAY
+    XAUTHORITY
+setenv =
+    PYTHONPATH = {toxinidir}
+extras =
+    dev
+commands =
+    pytest -v --color=yes --cov-report=xml --cov=cryopose --basetemp={envtmpdir} {posargs}
+
+[testenv:isort]
+skip_install = True
+deps = pre-commit
+commands = pre-commit run isort --all-files
+
+[testenv:flake8]
+skip_install = True
+deps = pre-commit
+commands = pre-commit run flake8 --all-files
+
+[testenv:black]
+skip_install = True
+deps = pre-commit
+commands = pre-commit run black --all-files
+
+[testenv:import-lint]
+skip_install = True
+deps = pre-commit
+commands = pre-commit run --hook-stage manual import-linter --all-files
+
+[testenv:package]
+isolated_build = true
+skip_install = true
+deps =
+    wheel
+    twine
+    build
+commands =
+    python -m build
+    python -m twine check dist/*


### PR DESCRIPTION
Mostly copy-pasting from other repos, should enable automatic testing and deployment. For deployment, we need first to add secrets to the organization/repo.

Also, ditch deprecated setup.py.
